### PR TITLE
Speed Test

### DIFF
--- a/Speed test command
+++ b/Speed test command
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+while true ;
+do
+    echo "Speedtest running..."
+    speedtest-cli --csv >> /home/pi/speedtest.log
+    echo "Speedtest finished..."
+    sleep 3600
+done


### PR DESCRIPTION
There are a few ways to measure upload and download speed. One of the simplest and easiest ways is to use the command “speedtest-cli,” which is a command-line version of the Ookla speedtest.net service. To install the command type:

apt-get install speedtest-cli
Here is what the output of the speedtest command looks like: for example

netbeez.net$ speedtest-cli
Retrieving speedtest.net configuration...
Testing from AT&T U-verse (99.35.xxx.xxx)...
Retrieving speedtest.net server list...
Selecting best server based on ping...
Hosted by Mimosa Networks (San Jose, CA) [5.00 km]: 33.185 ms Testing download speed................................................. Download: 61.03 Mbit/s
Testing upload speed................................................... Upload: 56.77 Mbit/s
It detected the device’s ISP (AT&T U-verse) and public IP (99.35.xxx.xxx). Then it found a close by server hosted by Mimosa Networks with latency 33.185 ms and 5.00 km away. And then it measured the download and upload speeds.